### PR TITLE
ci: pin codecov-action to a full-length commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         python -m pytest test_dot_auditor.py -v --cov=dot_auditor --cov-report=term-missing --cov-report=xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false


### PR DESCRIPTION
closes #2